### PR TITLE
Make Image.loadTexture call waitLoads callbacks

### DIFF
--- a/hxd/res/Image.hx
+++ b/hxd/res/Image.hx
@@ -719,6 +719,12 @@ class Image extends Resource {
 			load();
 		else
 			entry.load(load);
+		@:privateAccess if (tex.waitLoads != null) {
+			var arr = tex.waitLoads;
+			tex.waitLoads = null;
+			for (f in arr)
+				f();
+		}
 	}
 
 	public function toTexture():h3d.mat.Texture {


### PR DESCRIPTION
Currently the waitLoads callbacks are only called when you load a bitmap, this fixes that.